### PR TITLE
Deeplinks using browser location.hash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'rails_12factor', group: :production
 gem 'awesome_print'
 
 group :development, :test do
-  gem 'jasmine'
   gem 'rspec-rails'
   gem 'jasmine'
   gem 'jasmine-jquery-rails'

--- a/app/assets/javascripts/home.js
+++ b/app/assets/javascripts/home.js
@@ -1,24 +1,32 @@
-function CBGgetNewHeadline(event) {
-    getHeadline($(this).attr('id'));
-}
+CBG = {
+    getNewHeadline: function(event) {
+        CBG.getHeadline($(this).attr('id'));
+    },
 
-function getHeadline(headlineType) {
-    $.get('/home/generate',
-        'headline_type=' + headlineType,
-        onGetSuccess
-    );
-}
+    getBestOf: function(id) {
+        $.get('/home/generate', { id: id }, CBG.onGetSuccess );
+    },
 
-function onGetSuccess(xhr) {
-    // maybe this will do something else later, like register analytics
-    return true;
-}
+    getHeadline: function(headlineType) {
+        $.get('/home/generate', { headline_type: headlineType }, CBG.onGetSuccess);
+        CBG.resetLocationHash();
+    },
 
-function onShareSuccess(html) {
-    var $modalDiv = $(".ladom");
-    $(html).appendTo($modalDiv);
-    $modalDiv.modal();
-};
+    resetLocationHash: function() {
+        location.hash = "";
+    },
+
+    onGetSuccess: function(data, status, xhr, leaveHashAlone) {
+        // maybe this will do something else later, like register analytics
+        return true;
+    },
+
+    onShareSuccess: function(html) {
+        var $modalDiv = $(".ladom");
+        $(html).appendTo($modalDiv);
+        $modalDiv.modal();
+    }
+}
 
 
 window.onload = function () {
@@ -27,13 +35,10 @@ window.onload = function () {
             'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
         }
     });
-    if ($(".home #headline").length) {
-        getHeadline('listicle');
-    }
-    $(".clickbaits #clickbait-buttons .btn-clickbait").click(function(event) {
+    $("a.clickbaits #clickbait-buttons .btn-clickbait").click(function(event) {
         window.location = '/';
     });
-    $('.home #clickbait-buttons .btn-clickbait').click(CBGgetNewHeadline);
+    $('.home #clickbait-buttons .btn-clickbait').click(CBG.getNewHeadline);
     $('#manual-ajax').click(function(event){
         var $modalDiv = $(".ladom");
         event.preventDefault();
@@ -41,8 +46,8 @@ window.onload = function () {
             var headLine = $("#headline").text();
             var headlineType = "listicle";
             $.post("/clickbaits",
-                { clickbait: { headline: headLine, headline_type: headlineType }},
-                onShareSuccess);
+                   { clickbait: { headline: headLine, headline_type: headlineType }},
+                   CBG.onShareSuccess);
         } else {
             $modalDiv.modal();
         }
@@ -56,4 +61,11 @@ window.onload = function () {
         count: 100,
         overlap: 20
     });
+
+    // fetch best_of if the anchor tag is present
+    if (location.hash) {
+        CBG.getBestOf(location.hash.substr(1));
+    } else if ($('.home #headline').length) {
+        CBG.getHeadline('listicle');
+    }
 };

--- a/app/controllers/clickbaits_controller.rb
+++ b/app/controllers/clickbaits_controller.rb
@@ -1,9 +1,5 @@
 class ClickbaitsController < ApplicationController
 
-  def show
-    @clickbait = Clickbait.find params[:id]
-  end
-
   def create
     @clickbait = Clickbait.create title_params
     flash[:alert] = "There was a problem saving this Clickbait, sorryyyy!" if !@clickbait.valid?

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,7 +4,7 @@ class HomeController < ApplicationController
   end
 
   def generate
-    generate_clickbait
+    fetch_or_generate_clickbait(clickbait_params[:id])
     respond_to do |format|
       format.js {}
       format.json {
@@ -14,17 +14,29 @@ class HomeController < ApplicationController
   end
 
   def slackbot_generate
-    params[:headline_type] = params[:text]
-    generate_clickbait
+    fetch_or_generate_clickbait(nil)
     render plain: @clickbait.headline, status: 200
   end
 
   private
 
-  def generate_clickbait
-    @clickbait = ClickbaitBuilder.generate(params[:headline_type])
+  def clickbait_params
+    params[:headline_type] ||= params[:text]
+    params.permit(:id, :headline_type)
+  end
+
+  def fetch_or_generate_clickbait(best_of_id)
+    @clickbait = fetch_clickbait(best_of_id) || generate_clickbait
     @current_val = @clickbait.headline_type
     @headline = @clickbait.headline
+  end
+
+  def fetch_clickbait(best_of_id)
+    Clickbait.find_by(id: best_of_id) if best_of_id
+  end
+
+  def generate_clickbait
+    ClickbaitBuilder.generate(clickbait_params[:headline_type])
   end
 
 end

--- a/app/helpers/best_of_helper.rb
+++ b/app/helpers/best_of_helper.rb
@@ -1,0 +1,5 @@
+module BestOfHelper
+  def best_of_url(clickbait)
+    root_url(anchor: clickbait.to_param)
+  end
+end

--- a/app/views/clickbaits/create.html.erb
+++ b/app/views/clickbaits/create.html.erb
@@ -1,3 +1,3 @@
 <div class="">
-  <h2><%= link_to(@clickbait.headline, best_of_url(@clickbait.id))%></h2>
+  <h2><%= link_to(@clickbait.headline, best_of_url(@clickbait))%></h2>
 </div>

--- a/app/views/partials/_clickbait.html.erb
+++ b/app/views/partials/_clickbait.html.erb
@@ -4,8 +4,9 @@
 <div id='clickbait-buttons'>
   <% %w(listicle whathappens dontwanna whyi watchas).each do |htype| %>
       <% activeclass = (htype==@current_val) ? 'active' : ''%>
-      <span id="<%= htype %>" class="sparkley btn-clickbait <%= activeclass %> ">
-          <%= list_type_title htype %>
+      <% title = list_type_title(htype) %>
+      <span id="<%= htype %>" title="<%= title %>" class="sparkley btn-clickbait <%= activeclass %> ">
+          <%= title %>
         </span>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,7 @@ Rails.application.routes.draw do
     get 'generate'
   end
 
-  resource :clickbaits, only: [:create, :show]
-
-  get '/best_of/:id', to: 'clickbaits#show', as: :best_of
+  resource :clickbaits, only: [:create]
 
   get '/slackbot/generate', to: 'home#slackbot_generate'
 

--- a/spec/controllers/clickbaits_controller_spec.rb
+++ b/spec/controllers/clickbaits_controller_spec.rb
@@ -2,20 +2,6 @@ require 'rails_helper'
 
 describe ClickbaitsController, type: :controller do
   let(:headline) { "something hilarious" }
-  describe 'show' do
-
-    before do
-      clickbait = Clickbait.create headline: headline, headline_type: 'listicle'
-      get :show, id: clickbait.id
-    end
-
-    it 'sets a title' do
-      expect(assigns(:clickbait).headline).to eql headline
-    end
-    it 'is successful' do
-      expect(response).to be_success
-    end
-  end
 
   describe 'create' do
     subject { post :create, clickbait: { headline: headline, headline_type: 'listicle' } , format: :json }

--- a/spec/features/clickbaits_spec.rb
+++ b/spec/features/clickbaits_spec.rb
@@ -67,15 +67,22 @@ describe 'Clickbait Generator', :feature, :js do
 
 
   context  "when I visit a permalink" do
-    let(:clickbait) {
-      clickbait = Clickbait.create headline: "something hilarious", headline_type: 'listicle'
-    }
+    let(:clickbait) { Clickbait.create headline: "something hilarious", headline_type: 'listicle' }
+
     before do
-      visit "/best_of/#{clickbait.id}"
+      visit "/##{clickbait.id}"
     end
     it "shows the existing headline" do
       expect(page.find("#headline").text()).to eql clickbait.headline
     end
+    it "includes the clickbait id in the url hash" do
+      expect(page).to have_location_hash clickbait.id
+    end
+    it "clears the hash after fetching a new clickbait" do
+      find("#listicle").click
+      expect(page).to have_no_location_hash
+    end
+
     it_behaves_like "a Clickbait Generator page"
   end
 

--- a/spec/javascripts/generate_headline_spec.js
+++ b/spec/javascripts/generate_headline_spec.js
@@ -1,5 +1,5 @@
 describe('CBGgetNewHeadline', function(){
    it('works', function(){
-      expect(CBGgetNewHeadline()).toEqual(true);
+      expect(CBG.getNewHeadline()).toEqual(true);
    });
 });

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,13 @@
+module Capybara
+  class Session
+    def get_page_location_hash
+      self.evaluate_script( %q{ document.location.hash } )
+    end
+    def has_location_hash?(hash)
+      get_page_location_hash == "##{hash}"
+    end
+    def has_no_location_hash?
+      get_page_location_hash.empty?
+    end
+  end
+end


### PR DESCRIPTION
  Move best_of show handling onto the root page

    * use location.hash to pass the id of the 'best of' that you want to see
    * clear the hash when a new cb is generated
    * added best_of_url helper method (not in routes) that builds anchored link on root (/#<cb_id>)
    * add hash watcher in js on page load.
    * remove clickbaits#show
    * move javascript functions into a namespace (so they could be tested more easily)

